### PR TITLE
[오브젝트] ~9장 

### DIFF
--- a/DeliveryState.swift
+++ b/DeliveryState.swift
@@ -1,0 +1,22 @@
+enum DeliveryState {
+    case preparing        // 배송 준비 중
+    case shipped          // 발송 완료
+    case inTransit        // 배송 중
+    case delivered        // 배송 완료
+    case returned         // 반품 완료
+    
+    func isCancelAvailable(by policy: PurchaseCancelPolicy) -> Bool {
+        let states = self.getCancelAvailableStates(by: policy)
+        return states.contains(self)
+    }
+    
+    private func getCancelAvailableStates(by policy: PurchaseCancelPolicy) -> [DeliveryState] {
+        if policy is FreshGroceriesCancelPolicy {
+            return [.preparing]
+        }
+        if policy is ElectronicsCancelPolicy {
+            return [.preparing, .shipped, .inTransit, .delivered]
+        }
+        return []
+    }
+}

--- a/DeliveryState.swift
+++ b/DeliveryState.swift
@@ -4,19 +4,4 @@ enum DeliveryState {
     case inTransit        // 배송 중
     case delivered        // 배송 완료
     case returned         // 반품 완료
-    
-    func isCancelAvailable(by policy: PurchaseCancelPolicy) -> Bool {
-        let states = self.getCancelAvailableStates(by: policy)
-        return states.contains(self)
-    }
-    
-    private func getCancelAvailableStates(by policy: PurchaseCancelPolicy) -> [DeliveryState] {
-        if policy is FreshGroceriesCancelPolicy {
-            return [.preparing]
-        }
-        if policy is ElectronicsCancelPolicy {
-            return [.preparing, .shipped, .inTransit, .delivered]
-        }
-        return []
-    }
 }

--- a/ElectronicsCancelPolicy.swift
+++ b/ElectronicsCancelPolicy.swift
@@ -1,24 +1,20 @@
 class ElectronicsCancelPolicy: PurchaseCancelPolicy {
+    var cancelAvailablePurchaseStates: [PurchaseState] {
+        return [.pending, .completed]
+    }
     
+    var cancelAvailableDeliveryStates: [DeliveryState] {
+        return [.preparing, .shipped, .inTransit, .delivered]
+    }
+	
     internal var deadline: Int {
         return 31
     }
     
     func isCancelAvailable(_ purchase: PurchaseHistory) -> Bool {
-        if !purchase.purchaseState.isCancelAvailable(by: self) {
-            return false
-        }
-        
-        if !purchase.deliveryState.isCancelAvailable(by: self) {
-            return false
-        }
-        
         let passedDays = Calendar.current.dateComponents([.day], from: purchase.purchaseDate, to: Date()).day ?? 0
-
-				if passedDays > deadline {
-						return false
-				}
-
-        return true
+        return cancelAvailablePurchaseStates.contains(purchase.purchaseState) &&
+               cancelAvailableDeliveryStates.contains(purchase.deliveryState) &&
+               passedDays <= deadline
     }
 }

--- a/ElectronicsCancelPolicy.swift
+++ b/ElectronicsCancelPolicy.swift
@@ -1,0 +1,24 @@
+class ElectronicsCancelPolicy: PurchaseCancelPolicy {
+    
+    internal var deadline: Int {
+        return 31
+    }
+    
+    func isCancelAvailable(_ purchase: PurchaseHistory) -> Bool {
+        if !purchase.purchaseState.isCancelAvailable(by: self) {
+            return false
+        }
+        
+        if !purchase.deliveryState.isCancelAvailable(by: self) {
+            return false
+        }
+        
+        let passedDays = Calendar.current.dateComponents([.day], from: purchase.purchaseDate, to: Date()).day ?? 0
+
+				if passedDays > deadline {
+						return false
+				}
+
+        return true
+    }
+}

--- a/FreshGroceriesCancelPolicy.swift
+++ b/FreshGroceriesCancelPolicy.swift
@@ -1,13 +1,14 @@
 class FreshGroceriesCancelPolicy: PurchaseCancelPolicy {
+    var cancelAvailablePurchaseStates: [PurchaseState] {
+        return [.pending, .completed]
+    }
+    
+    var cancelAvailableDeliveryStates: [DeliveryState] {
+        return [.preparing]
+    }
+    
     func isCancelAvailable(_ purchase: PurchaseHistory) -> Bool {
-        if !purchase.purchaseState.isCancelAvailable(by: self) {
-            return false
-        }
-        
-        if !purchase.deliveryState.isCancelAvailable(by: self) {
-            return false
-        }
-        
-        return true
+        return cancelAvailablePurchaseStates.contains(purchase.purchaseState) &&
+               cancelAvailableDeliveryStates.contains(purchase.deliveryState)
     }
 }

--- a/FreshGroceriesCancelPolicy.swift
+++ b/FreshGroceriesCancelPolicy.swift
@@ -1,0 +1,13 @@
+class FreshGroceriesCancelPolicy: PurchaseCancelPolicy {
+    func isCancelAvailable(_ purchase: PurchaseHistory) -> Bool {
+        if !purchase.purchaseState.isCancelAvailable(by: self) {
+            return false
+        }
+        
+        if !purchase.deliveryState.isCancelAvailable(by: self) {
+            return false
+        }
+        
+        return true
+    }
+}

--- a/LGElectronicsCancelPolicy.swift
+++ b/LGElectronicsCancelPolicy.swift
@@ -1,0 +1,5 @@
+class LGElectronicsCancelPolicy: ElectronicsCancelPolicy {
+    override var deadline: Int {
+        return 7
+    }
+}

--- a/PaymentMethod.swift
+++ b/PaymentMethod.swift
@@ -1,0 +1,21 @@
+protocol PaymentMethod {
+    func processRefund(amount: Double)
+}
+
+class CreditCardPayment: PaymentMethod {
+    func processRefund(amount: Double) {
+        print("Refunding \(amount) to credit card.")
+    }
+}
+
+class PayPalPayment: PaymentMethod {
+    func processRefund(amount: Double) {
+        print("Refunding \(amount) via PayPal.")
+    }
+}
+
+class BankTransferPayment: PaymentMethod {
+    func processRefund(amount: Double) {
+        print("Refunding \(amount) via bank transfer.")
+    }
+}

--- a/PurchaseCancelManager.swift
+++ b/PurchaseCancelManager.swift
@@ -3,12 +3,10 @@ class PurchaseCancelManager {
     
     private init() {}
     
-    func cancelPurchase(_ purchase: PurchaseHistory, with policy: PurchaseCancelPolicy) -> PurchaseHistory {
+    func cancelPurchase(_ purchase: PurchaseHistory, with policy: PurchaseCancelPolicy) -> Bool {
         guard policy.isCancelAvailable(purchase) else {
-            return purchase
+            return false
         }
-        let newPurchaseHistory = PurchaseHistory(purchaseState: .cancelled, 
-						 deliveryState: purchase.deliveryState)
-	return newPurchaseHistory
+	return true
     }
 }

--- a/PurchaseCancelManager.swift
+++ b/PurchaseCancelManager.swift
@@ -8,7 +8,7 @@ class PurchaseCancelManager {
             return purchase
         }
         let newPurchaseHistory = PurchaseHistory(purchaseState: .cancelled, 
-																					       deliveryState: purchase.deliveryState)
-			  return newPurchaseHistory
+						 deliveryState: purchase.deliveryState)
+	return newPurchaseHistory
     }
 }

--- a/PurchaseCancelManager.swift
+++ b/PurchaseCancelManager.swift
@@ -1,0 +1,14 @@
+class PurchaseCancelManager {
+    static let shared = PurchaseCancelManager()
+    
+    private init() {}
+    
+    func cancelPurchase(_ purchase: PurchaseHistory, with policy: PurchaseCancelPolicy) -> PurchaseHistory {
+        guard policy.isCancelAvailable(purchase) else {
+            return purchase
+        }
+        let newPurchaseHistory = PurchaseHistory(purchaseState: .cancelled, 
+																					       deliveryState: purchase.deliveryState)
+			  return newPurchaseHistory
+    }
+}

--- a/PurchaseCancelPolicy.swift
+++ b/PurchaseCancelPolicy.swift
@@ -1,0 +1,3 @@
+protocol PurchaseCancelPolicy {
+    func isCancelAvailable(_ purchase: PurchaseHistory) -> Bool
+}

--- a/PurchaseCancelPolicy.swift
+++ b/PurchaseCancelPolicy.swift
@@ -1,3 +1,5 @@
 protocol PurchaseCancelPolicy {
     func isCancelAvailable(_ purchase: PurchaseHistory) -> Bool
+    var cancelAvailablePurchaseStates: [PurchaseState] { get }
+    var cancelAvailableDeliveryStates: [DeliveryState] { get }
 }

--- a/PurchaseHistory.swift
+++ b/PurchaseHistory.swift
@@ -1,0 +1,6 @@
+struct PurchaseHistory {
+		let purchaseState: PurchaseState
+    let deliveryState: DeliveryState
+		let paymentMethod: PaymentMethod
+		let purchaseDate: Date 
+}

--- a/PurchaseHistory.swift
+++ b/PurchaseHistory.swift
@@ -1,6 +1,6 @@
 struct PurchaseHistory {
-		let purchaseState: PurchaseState
+    let purchaseState: PurchaseState
     let deliveryState: DeliveryState
-		let paymentMethod: PaymentMethod
-		let purchaseDate: Date 
+    let paymentMethod: PaymentMethod
+    let purchaseDate: Date 
 }

--- a/PurchaseState.swift
+++ b/PurchaseState.swift
@@ -4,19 +4,4 @@ enum PurchaseState {
     case failed         // 구매 실패
     case refunded       // 환불 완료
     case cancelled      // 구매 취소
-    
-    func isCancelAvailable(by policy: PurchaseCancelPolicy) -> Bool {
-        let states = self.getCancelAvailableStates(by: policy)
-        return states.contains(self)
-    }
-    
-    private func getCancelAvailableStates(by policy: PurchaseCancelPolicy) -> [PurchaseState] {
-        if policy is FreshGroceriesCancelPolicy {
-            return [.pending, .completed]
-        }
-        if policy is ElectronicsCancelPolicy {
-            return [.pending, .completed]
-        }
-        return []
-    }
 }

--- a/PurchaseState.swift
+++ b/PurchaseState.swift
@@ -1,0 +1,22 @@
+enum PurchaseState {
+    case pending        // 구매 대기 중
+    case completed      // 구매 완료
+    case failed         // 구매 실패
+    case refunded       // 환불 완료
+    case cancelled      // 구매 취소
+    
+    func isCancelAvailable(by policy: PurchaseCancelPolicy) -> Bool {
+        let states = self.getCancelAvailableStates(by: policy)
+        return states.contains(self)
+    }
+    
+    private func getCancelAvailableStates(by policy: PurchaseCancelPolicy) -> [PurchaseState] {
+        if policy is FreshGroceriesCancelPolicy {
+            return [.pending, .completed]
+        }
+        if policy is ElectronicsCancelPolicy {
+            return [.pending, .completed]
+        }
+        return []
+    }
+}

--- a/RefundManager.swift
+++ b/RefundManager.swift
@@ -3,11 +3,13 @@ class RefundManager {
     
     private init() {}
     
-    func refundPurchase(_ purchase: PurchaseHistory, amount: Double) {
+    func refundPurchase(_ purchase: PurchaseHistory, amount: Double) -> PurchaseHistory? {
         guard purchase.purchaseState == .completed || purchase.purchaseState == .cancelled else {
-            return
+            return nil
         }
-        purchase.purchaseState = .refunded
         purchase.paymentMethod.processRefund(amount: amount)
+        let newPurchaseHistory = PurchaseHistory(purchaseState: .refunded, 
+						                         deliveryState: purchase.deliveryState)
+	    return newPurchaseHistory
     }
 }

--- a/RefundManager.swift
+++ b/RefundManager.swift
@@ -1,0 +1,13 @@
+class RefundManager {
+    static let shared = RefundManager()
+    
+    private init() {}
+    
+    func refundPurchase(_ purchase: PurchaseHistory, amount: Double) {
+        guard purchase.purchaseState == .completed || purchase.purchaseState == .cancelled else {
+            return
+        }
+        purchase.purchaseState = .refunded
+        purchase.paymentMethod.processRefund(amount: amount)
+    }
+}

--- a/RefundManager.swift
+++ b/RefundManager.swift
@@ -3,13 +3,11 @@ class RefundManager {
     
     private init() {}
     
-    func refundPurchase(_ purchase: PurchaseHistory, amount: Double) -> PurchaseHistory? {
+    func refundPurchase(_ purchase: PurchaseHistory, amount: Double) -> Bool {
         guard purchase.purchaseState == .completed || purchase.purchaseState == .cancelled else {
-            return nil
+            return false
         }
         purchase.paymentMethod.processRefund(amount: amount)
-        let newPurchaseHistory = PurchaseHistory(purchaseState: .refunded, 
-					         deliveryState: purchase.deliveryState)
-  	return newPurchaseHistory
+	return true
     }
 }

--- a/RefundManager.swift
+++ b/RefundManager.swift
@@ -9,7 +9,7 @@ class RefundManager {
         }
         purchase.paymentMethod.processRefund(amount: amount)
         let newPurchaseHistory = PurchaseHistory(purchaseState: .refunded, 
-						                         deliveryState: purchase.deliveryState)
-	    return newPurchaseHistory
+					         deliveryState: purchase.deliveryState)
+  	return newPurchaseHistory
     }
 }


### PR DESCRIPTION
# 주요 변경 내용
## 1. 타입 체크(is 연산자) 제거 및 정책 기반 구조 개선
기존 PurchaseState와 DeliveryState에서 isCancelAvailable을 확인할 때,
policy is FreshGroceriesCancelPolicy처럼 is 연산자로 타입을 체크하고 있습니다. [(기존코드 참고)](https://www.notion.so/ver-2-0-17c8b528fc97809ca2b6da07de8dea2d?pvs=4#018d99697f7746a393835a4e29a9bf44)
이 방식은 새로운 PurchaseCancelPolicy가 추가될 때마다 PurchaseState와 DeliveryState의 기존 코드도 수정해야 하는 문제를 발생시킵니다.
객체지향 원칙 중 **개방**-**폐쇄** **원칙**(Open-Closed Principle)을 위반하며, 유지보수성과 확장성이 떨어지는 코드 구조가 됩니다.

이를 해결하기 위해 PurchaseCancelPolicy에 cancelAvailablePurchaseStates와 cancelAvailableDeliveryStates 프로퍼티를 추가하여,
각 정책이 직접 '취소 가능한 구매 상태 및 배송 상태'를 정의하도록 변경했습니다.

## 2. PurchaseCancelManager 및 RefundManager 개선 
기존 PurchaseCancelManager의 cancelPurchase 메서드는 취소된 PurchaseHistory 객체를 반환하는 방식이었습니다. [(기존코드 참고)](https://www.notion.so/ver-2-0-17c8b528fc97809ca2b6da07de8dea2d?pvs=4#17c8b528fc978071b6c8e8cb88af6710)

그러나 이는 불필요한 객체 생성을 유발할 수 있으며, 호출하는 입장에서도 취소 요청의 성공 여부를 직접 확인하기 어려운 구조였습니다.

이를 해결하기 위해 cancelPurchase가 취소 성공 여부를 Bool 값으로 반환하도록 변경하였습니다.

또한 같은 맥락에서 RefundManager도 환불 성공 여부를 반환하는 것이 맞다고 여겨 그렇게 변경하였습니다.