### PR TITLE
[오브젝트] 10장

### DIFF
--- a/DeliveryState.swift
+++ b/DeliveryState.swift
@@ -1,0 +1,22 @@
+enum DeliveryState {
+    case preparing        // 배송 준비 중
+    case shipped          // 발송 완료
+    case inTransit        // 배송 중
+    case delivered        // 배송 완료
+    case returned         // 반품 완료
+    
+    func isCancelAvailable(by policy: PurchaseCancelPolicy) -> Bool {
+        let states = self.getCancelAvailableStates(by: policy)
+        return states.contains(self)
+    }
+    
+    private func getCancelAvailableStates(by policy: PurchaseCancelPolicy) -> [DeliveryState] {
+        if policy is FreshGroceriesCancelPolicy {
+            return [.preparing]
+        }
+        if policy is ElectronicsCancelPolicy {
+            return [.preparing, .shipped, .inTransit, .delivered]
+        }
+        return []
+    }
+}

--- a/DeliveryState.swift
+++ b/DeliveryState.swift
@@ -4,19 +4,4 @@ enum DeliveryState {
     case inTransit        // 배송 중
     case delivered        // 배송 완료
     case returned         // 반품 완료
-    
-    func isCancelAvailable(by policy: PurchaseCancelPolicy) -> Bool {
-        let states = self.getCancelAvailableStates(by: policy)
-        return states.contains(self)
-    }
-    
-    private func getCancelAvailableStates(by policy: PurchaseCancelPolicy) -> [DeliveryState] {
-        if policy is FreshGroceriesCancelPolicy {
-            return [.preparing]
-        }
-        if policy is ElectronicsCancelPolicy {
-            return [.preparing, .shipped, .inTransit, .delivered]
-        }
-        return []
-    }
 }

--- a/ElectronicsCancelPolicy.swift
+++ b/ElectronicsCancelPolicy.swift
@@ -6,11 +6,13 @@ class ElectronicsCancelPolicy: PurchaseCancelPolicy {
     var cancelAvailableDeliveryStates: [DeliveryState] {
         return [.preparing, .shipped, .inTransit, .delivered]
     }
+
+    let deadline: Int
 	
-    internal var deadline: Int {
-        return 31
+    init(deadline: Int) {
+	self.deadline = deadline
     }
-    
+
     func isCancelAvailable(_ purchase: PurchaseHistory) -> Bool {
         let passedDays = Calendar.current.dateComponents([.day], from: purchase.purchaseDate, to: Date()).day ?? 0
         return cancelAvailablePurchaseStates.contains(purchase.purchaseState) &&

--- a/ElectronicsCancelPolicy.swift
+++ b/ElectronicsCancelPolicy.swift
@@ -1,24 +1,20 @@
 class ElectronicsCancelPolicy: PurchaseCancelPolicy {
+    var cancelAvailablePurchaseStates: [PurchaseState] {
+        return [.pending, .completed]
+    }
     
+    var cancelAvailableDeliveryStates: [DeliveryState] {
+        return [.preparing, .shipped, .inTransit, .delivered]
+    }
+	
     internal var deadline: Int {
         return 31
     }
     
     func isCancelAvailable(_ purchase: PurchaseHistory) -> Bool {
-        if !purchase.purchaseState.isCancelAvailable(by: self) {
-            return false
-        }
-        
-        if !purchase.deliveryState.isCancelAvailable(by: self) {
-            return false
-        }
-        
         let passedDays = Calendar.current.dateComponents([.day], from: purchase.purchaseDate, to: Date()).day ?? 0
-
-				if passedDays > deadline {
-						return false
-				}
-
-        return true
+        return cancelAvailablePurchaseStates.contains(purchase.purchaseState) &&
+               cancelAvailableDeliveryStates.contains(purchase.deliveryState) &&
+               passedDays <= deadline
     }
 }

--- a/ElectronicsCancelPolicy.swift
+++ b/ElectronicsCancelPolicy.swift
@@ -1,0 +1,24 @@
+class ElectronicsCancelPolicy: PurchaseCancelPolicy {
+    
+    internal var deadline: Int {
+        return 31
+    }
+    
+    func isCancelAvailable(_ purchase: PurchaseHistory) -> Bool {
+        if !purchase.purchaseState.isCancelAvailable(by: self) {
+            return false
+        }
+        
+        if !purchase.deliveryState.isCancelAvailable(by: self) {
+            return false
+        }
+        
+        let passedDays = Calendar.current.dateComponents([.day], from: purchase.purchaseDate, to: Date()).day ?? 0
+
+				if passedDays > deadline {
+						return false
+				}
+
+        return true
+    }
+}

--- a/FreshGroceriesCancelPolicy.swift
+++ b/FreshGroceriesCancelPolicy.swift
@@ -1,13 +1,14 @@
 class FreshGroceriesCancelPolicy: PurchaseCancelPolicy {
+    var cancelAvailablePurchaseStates: [PurchaseState] {
+        return [.pending, .completed]
+    }
+    
+    var cancelAvailableDeliveryStates: [DeliveryState] {
+        return [.preparing]
+    }
+    
     func isCancelAvailable(_ purchase: PurchaseHistory) -> Bool {
-        if !purchase.purchaseState.isCancelAvailable(by: self) {
-            return false
-        }
-        
-        if !purchase.deliveryState.isCancelAvailable(by: self) {
-            return false
-        }
-        
-        return true
+        return cancelAvailablePurchaseStates.contains(purchase.purchaseState) &&
+               cancelAvailableDeliveryStates.contains(purchase.deliveryState)
     }
 }

--- a/FreshGroceriesCancelPolicy.swift
+++ b/FreshGroceriesCancelPolicy.swift
@@ -1,0 +1,13 @@
+class FreshGroceriesCancelPolicy: PurchaseCancelPolicy {
+    func isCancelAvailable(_ purchase: PurchaseHistory) -> Bool {
+        if !purchase.purchaseState.isCancelAvailable(by: self) {
+            return false
+        }
+        
+        if !purchase.deliveryState.isCancelAvailable(by: self) {
+            return false
+        }
+        
+        return true
+    }
+}

--- a/LGElectronicsCancelPolicy.swift
+++ b/LGElectronicsCancelPolicy.swift
@@ -1,0 +1,5 @@
+class LGElectronicsCancelPolicy: ElectronicsCancelPolicy {
+    override var deadline: Int {
+        return 7
+    }
+}

--- a/LGElectronicsCancelPolicy.swift
+++ b/LGElectronicsCancelPolicy.swift
@@ -1,5 +1,0 @@
-class LGElectronicsCancelPolicy: ElectronicsCancelPolicy {
-    override var deadline: Int {
-        return 7
-    }
-}

--- a/PaymentMethod.swift
+++ b/PaymentMethod.swift
@@ -1,21 +1,24 @@
 protocol PaymentMethod {
-    func processRefund(amount: Double)
+    func processRefund(amount: Double) -> Bool
 }
 
 class CreditCardPayment: PaymentMethod {
-    func processRefund(amount: Double) {
+    func processRefund(amount: Double) -> Bool {
         print("Refunding \(amount) to credit card.")
+        return true
     }
 }
 
 class PayPalPayment: PaymentMethod {
-    func processRefund(amount: Double) {
+    func processRefund(amount: Double) -> Bool {
         print("Refunding \(amount) via PayPal.")
+        return true
     }
 }
 
 class BankTransferPayment: PaymentMethod {
-    func processRefund(amount: Double) {
+    func processRefund(amount: Double) -> Bool {
         print("Refunding \(amount) via bank transfer.")
+        return true
     }
 }

--- a/PaymentMethod.swift
+++ b/PaymentMethod.swift
@@ -1,0 +1,21 @@
+protocol PaymentMethod {
+    func processRefund(amount: Double)
+}
+
+class CreditCardPayment: PaymentMethod {
+    func processRefund(amount: Double) {
+        print("Refunding \(amount) to credit card.")
+    }
+}
+
+class PayPalPayment: PaymentMethod {
+    func processRefund(amount: Double) {
+        print("Refunding \(amount) via PayPal.")
+    }
+}
+
+class BankTransferPayment: PaymentMethod {
+    func processRefund(amount: Double) {
+        print("Refunding \(amount) via bank transfer.")
+    }
+}

--- a/PaymentTransaction.swift
+++ b/PaymentTransaction.swift
@@ -1,0 +1,5 @@
+struct PaymentTransaction {
+    let uid: String
+    let method: PaymentMethod
+    let amount: Int
+}

--- a/PurchaseCancelManager.swift
+++ b/PurchaseCancelManager.swift
@@ -3,12 +3,10 @@ class PurchaseCancelManager {
     
     private init() {}
     
-    func cancelPurchase(_ purchase: PurchaseHistory, with policy: PurchaseCancelPolicy) -> PurchaseHistory {
+    func cancelPurchase(_ purchase: PurchaseHistory, with policy: PurchaseCancelPolicy) -> Bool {
         guard policy.isCancelAvailable(purchase) else {
-            return purchase
+            return false
         }
-        let newPurchaseHistory = PurchaseHistory(purchaseState: .cancelled, 
-						 deliveryState: purchase.deliveryState)
-	return newPurchaseHistory
+	return true
     }
 }

--- a/PurchaseCancelManager.swift
+++ b/PurchaseCancelManager.swift
@@ -8,7 +8,7 @@ class PurchaseCancelManager {
             return purchase
         }
         let newPurchaseHistory = PurchaseHistory(purchaseState: .cancelled, 
-																					       deliveryState: purchase.deliveryState)
-			  return newPurchaseHistory
+						 deliveryState: purchase.deliveryState)
+	return newPurchaseHistory
     }
 }

--- a/PurchaseCancelManager.swift
+++ b/PurchaseCancelManager.swift
@@ -1,0 +1,14 @@
+class PurchaseCancelManager {
+    static let shared = PurchaseCancelManager()
+    
+    private init() {}
+    
+    func cancelPurchase(_ purchase: PurchaseHistory, with policy: PurchaseCancelPolicy) -> PurchaseHistory {
+        guard policy.isCancelAvailable(purchase) else {
+            return purchase
+        }
+        let newPurchaseHistory = PurchaseHistory(purchaseState: .cancelled, 
+																					       deliveryState: purchase.deliveryState)
+			  return newPurchaseHistory
+    }
+}

--- a/PurchaseCancelPolicy.swift
+++ b/PurchaseCancelPolicy.swift
@@ -1,0 +1,3 @@
+protocol PurchaseCancelPolicy {
+    func isCancelAvailable(_ purchase: PurchaseHistory) -> Bool
+}

--- a/PurchaseCancelPolicy.swift
+++ b/PurchaseCancelPolicy.swift
@@ -1,3 +1,5 @@
 protocol PurchaseCancelPolicy {
     func isCancelAvailable(_ purchase: PurchaseHistory) -> Bool
+    var cancelAvailablePurchaseStates: [PurchaseState] { get }
+    var cancelAvailableDeliveryStates: [DeliveryState] { get }
 }

--- a/PurchaseHistory.swift
+++ b/PurchaseHistory.swift
@@ -1,0 +1,6 @@
+struct PurchaseHistory {
+		let purchaseState: PurchaseState
+    let deliveryState: DeliveryState
+		let paymentMethod: PaymentMethod
+		let purchaseDate: Date 
+}

--- a/PurchaseHistory.swift
+++ b/PurchaseHistory.swift
@@ -1,6 +1,6 @@
 struct PurchaseHistory {
-		let purchaseState: PurchaseState
+    let purchaseState: PurchaseState
     let deliveryState: DeliveryState
-		let paymentMethod: PaymentMethod
-		let purchaseDate: Date 
+    let paymentMethod: PaymentMethod
+    let purchaseDate: Date 
 }

--- a/PurchaseHistory.swift
+++ b/PurchaseHistory.swift
@@ -1,6 +1,6 @@
 struct PurchaseHistory {
     let purchaseState: PurchaseState
     let deliveryState: DeliveryState
-    let paymentMethod: PaymentMethod
+    let paymentTransaction: [PaymentTransaction]
     let purchaseDate: Date 
 }

--- a/PurchaseState.swift
+++ b/PurchaseState.swift
@@ -4,19 +4,4 @@ enum PurchaseState {
     case failed         // 구매 실패
     case refunded       // 환불 완료
     case cancelled      // 구매 취소
-    
-    func isCancelAvailable(by policy: PurchaseCancelPolicy) -> Bool {
-        let states = self.getCancelAvailableStates(by: policy)
-        return states.contains(self)
-    }
-    
-    private func getCancelAvailableStates(by policy: PurchaseCancelPolicy) -> [PurchaseState] {
-        if policy is FreshGroceriesCancelPolicy {
-            return [.pending, .completed]
-        }
-        if policy is ElectronicsCancelPolicy {
-            return [.pending, .completed]
-        }
-        return []
-    }
 }

--- a/PurchaseState.swift
+++ b/PurchaseState.swift
@@ -1,0 +1,22 @@
+enum PurchaseState {
+    case pending        // 구매 대기 중
+    case completed      // 구매 완료
+    case failed         // 구매 실패
+    case refunded       // 환불 완료
+    case cancelled      // 구매 취소
+    
+    func isCancelAvailable(by policy: PurchaseCancelPolicy) -> Bool {
+        let states = self.getCancelAvailableStates(by: policy)
+        return states.contains(self)
+    }
+    
+    private func getCancelAvailableStates(by policy: PurchaseCancelPolicy) -> [PurchaseState] {
+        if policy is FreshGroceriesCancelPolicy {
+            return [.pending, .completed]
+        }
+        if policy is ElectronicsCancelPolicy {
+            return [.pending, .completed]
+        }
+        return []
+    }
+}

--- a/RefundManager.swift
+++ b/RefundManager.swift
@@ -3,11 +3,13 @@ class RefundManager {
     
     private init() {}
     
-    func refundPurchase(_ purchase: PurchaseHistory, amount: Double) {
+    func refundPurchase(_ purchase: PurchaseHistory, amount: Double) -> PurchaseHistory? {
         guard purchase.purchaseState == .completed || purchase.purchaseState == .cancelled else {
-            return
+            return nil
         }
-        purchase.purchaseState = .refunded
         purchase.paymentMethod.processRefund(amount: amount)
+        let newPurchaseHistory = PurchaseHistory(purchaseState: .refunded, 
+						                         deliveryState: purchase.deliveryState)
+	    return newPurchaseHistory
     }
 }

--- a/RefundManager.swift
+++ b/RefundManager.swift
@@ -1,0 +1,13 @@
+class RefundManager {
+    static let shared = RefundManager()
+    
+    private init() {}
+    
+    func refundPurchase(_ purchase: PurchaseHistory, amount: Double) {
+        guard purchase.purchaseState == .completed || purchase.purchaseState == .cancelled else {
+            return
+        }
+        purchase.purchaseState = .refunded
+        purchase.paymentMethod.processRefund(amount: amount)
+    }
+}

--- a/RefundManager.swift
+++ b/RefundManager.swift
@@ -3,13 +3,11 @@ class RefundManager {
     
     private init() {}
     
-    func refundPurchase(_ purchase: PurchaseHistory, amount: Double) -> PurchaseHistory? {
+    func refundPurchase(_ purchase: PurchaseHistory, amount: Double) -> Bool {
         guard purchase.purchaseState == .completed || purchase.purchaseState == .cancelled else {
-            return nil
+            return false
         }
         purchase.paymentMethod.processRefund(amount: amount)
-        let newPurchaseHistory = PurchaseHistory(purchaseState: .refunded, 
-					         deliveryState: purchase.deliveryState)
-  	return newPurchaseHistory
+	return true
     }
 }

--- a/RefundManager.swift
+++ b/RefundManager.swift
@@ -7,7 +7,11 @@ class RefundManager {
         guard purchase.purchaseState == .completed || purchase.purchaseState == .cancelled else {
             return false
         }
-        purchase.paymentMethod.processRefund(amount: amount)
+
+	for paymentTransaction in purchase.paymentTransactionList {
+	    paymentTransaction.processRefund(amount: amount)
+	}
+	    
 	return true
     }
 }

--- a/RefundManager.swift
+++ b/RefundManager.swift
@@ -3,15 +3,18 @@ class RefundManager {
     
     private init() {}
     
-    func refundPurchase(_ purchase: PurchaseHistory, amount: Double) -> Bool {
+    func refundPurchase(_ purchase: PurchaseHistory, amount: Double) -> [(Bool, String)] {
         guard purchase.purchaseState == .completed || purchase.purchaseState == .cancelled else {
-            return false
+            return purchase.paymentTransactionList.map({ (false, $0.uid) }) 
         }
 
+	var resultList: [(Bool, String)] = []
+
 	for paymentTransaction in purchase.paymentTransactionList {
-	    paymentTransaction.processRefund(amount: amount)
+	    let result = paymentTransaction.processRefund(amount: amount)
+	    resultList.append((result, paymentTransaction.uid))
 	}
 	    
-	return true
+	return resultList
     }
 }

--- a/RefundManager.swift
+++ b/RefundManager.swift
@@ -9,7 +9,7 @@ class RefundManager {
         }
         purchase.paymentMethod.processRefund(amount: amount)
         let newPurchaseHistory = PurchaseHistory(purchaseState: .refunded, 
-						                         deliveryState: purchase.deliveryState)
-	    return newPurchaseHistory
+					         deliveryState: purchase.deliveryState)
+  	return newPurchaseHistory
     }
 }


### PR DESCRIPTION
# 주요 변경 내용
## 1. PurchaseHistory에서 결제 수단을 PaymentTransaction으로 관리
기존에는 PurchaseHistory에서 결제 수단을 PaymentMethod 하나만 가지고 관리하고 있었습니다.

이 방식은 새로운 결제 방식이 추가될 때마다 PurchaseHistory 클래스를 수정해야 하므로 유지보수가 어렵고, 다양한 결제 수단을 처리하기도 어렵습니다. (ex. 결제금액의 반은 카드로, 반은 포인트로 계산한 경우)

그래서 결제수단별 결제 정보를 담는 PaymentTransaction 구조체를 만들고, PurchaseHistory는 이를 배열로 갖게 함으로써 결제 수단의 유연한 확장과 결합도 감소를 구현하려 했습니다.

## 2. ElectronicsCancelPolicy에서 deadline을 생성자 주입 방식으로 변경

기존에는 ElectronicsCancelPolicy에서 deadline 값을 하드코딩하여 사용하고 있었습니다.

deadline 값이 고정되어 있기 때문에 다양한 제품군에 맞는 정책을 만들려면 그때마다 새로운 CancelPolicy 클래스를 작성해야 했습니다.

그래서 ElectronicsCancelPolicy에서 deadline 값을 생성자 주입 방식으로 변경하였고 이를 통해 정책을 보다 유연하게 관리할 수 있게 되었습니다.