### PR TITLE
[오브젝트] 11장

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Kotlin2JvmCompilerArguments">
+    <option name="jvmTarget" value="1.8" />
+  </component>
+</project>

--- a/.idea/libraries/KotlinJavaRuntime.xml
+++ b/.idea/libraries/KotlinJavaRuntime.xml
@@ -1,0 +1,23 @@
+<component name="libraryTable">
+  <library name="KotlinJavaRuntime" type="repository">
+    <properties maven-id="org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.0.21" />
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.0.21/kotlin-stdlib-jdk8-2.0.21.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib/2.0.21/kotlin-stdlib-2.0.21.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/annotations/13.0/annotations-13.0.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.0.21/kotlin-stdlib-jdk7-2.0.21.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.0.21/kotlin-stdlib-jdk8-2.0.21-javadoc.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib/2.0.21/kotlin-stdlib-2.0.21-javadoc.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/annotations/13.0/annotations-13.0-javadoc.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.0.21/kotlin-stdlib-jdk7-2.0.21-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.0.21/kotlin-stdlib-jdk8-2.0.21-sources.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib/2.0.21/kotlin-stdlib-2.0.21-sources.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/annotations/13.0/annotations-13.0-sources.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.0.21/kotlin-stdlib-jdk7-2.0.21-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_22" default="true" project-jdk-name="22" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/object11.iml" filepath="$PROJECT_DIR$/.idea/object11.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/object11.iml
+++ b/.idea/object11.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="KotlinJavaRuntime" level="project" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/AdditionalRatePolicy.kt
+++ b/AdditionalRatePolicy.kt
@@ -1,0 +1,8 @@
+abstract class AdditionalRatePolicy(private val ratePolicies: List<RatePolicy>) : RatePolicy {
+    override fun calculateFee(electricity: Electricity): Double {
+        val fee = ratePolicies.sumOf { it.calculateFee(electricity) }
+        return afterCalculated(fee)
+    }
+
+    abstract protected fun afterCalculated(fee: Double): Double
+}

--- a/BasicRatePolicy.kt
+++ b/BasicRatePolicy.kt
@@ -1,0 +1,18 @@
+abstract class BasicRatePolicy: RatePolicy {
+
+    override fun calculateFee(electricity: Electricity): Double {
+        val result = if(electricity.usage < Electricity.MINIMUM_USAGE) {
+            0.0
+        } else if(electricity.usage in (Electricity.MINIMUM_USAGE + 1)..<Electricity.LOW_USAGE) {
+            910.0
+        } else if(electricity.usage in (Electricity.LOW_USAGE + 1)..<Electricity.HIGH_USAGE) {
+            1600.0
+        } else {
+            7300.0
+        }
+        return result
+    }
+
+    protected abstract fun calculateElectricityChargePolicy(electricity: Electricity): Double
+
+}

--- a/BasicRatePolicy.kt
+++ b/BasicRatePolicy.kt
@@ -1,4 +1,4 @@
-abstract class BasicRatePolicy: RatePolicy {
+class BasicRatePolicy: RatePolicy {
 
     override fun calculateFee(electricity: Electricity): Double {
         val result = if(electricity.usage < Electricity.MINIMUM_USAGE) {
@@ -12,7 +12,5 @@ abstract class BasicRatePolicy: RatePolicy {
         }
         return result
     }
-
-    protected abstract fun calculateElectricityChargePolicy(electricity: Electricity): Double
 
 }

--- a/ClimateEnvironmentRatePolicy.kt
+++ b/ClimateEnvironmentRatePolicy.kt
@@ -1,0 +1,9 @@
+class ClimateEnvironmentRatePolicy: BasicRatePolicy() {
+    override fun calculateElectricityChargePolicy(electricity: Electricity): Double {
+        return electricity.usage * ENVIRONMENT_FEE
+    }
+
+    companion object {
+        private const val ENVIRONMENT_FEE = 9.0
+    }
+}

--- a/ClimateEnvironmentRatePolicy.kt
+++ b/ClimateEnvironmentRatePolicy.kt
@@ -1,9 +1,5 @@
-class ClimateEnvironmentRatePolicy: RatePolicy {
+class ClimateEnvironmentRatePolicy(private val environmentFee: Double): RatePolicy {
     override fun calculateFee(electricity: Electricity): Double {
-        return electricity.usage * ENVIRONMENT_FEE
-    }
-
-    companion object {
-        private const val ENVIRONMENT_FEE = 9.0
+        return electricity.usage * environmentFee
     }
 }

--- a/ClimateEnvironmentRatePolicy.kt
+++ b/ClimateEnvironmentRatePolicy.kt
@@ -1,5 +1,5 @@
-class ClimateEnvironmentRatePolicy: BasicRatePolicy() {
-    override fun calculateElectricityChargePolicy(electricity: Electricity): Double {
+class ClimateEnvironmentRatePolicy: RatePolicy {
+    override fun calculateFee(electricity: Electricity): Double {
         return electricity.usage * ENVIRONMENT_FEE
     }
 

--- a/Electricity.kt
+++ b/Electricity.kt
@@ -1,0 +1,13 @@
+class Electricity (val usage: Int, private val ratePolicy: RatePolicy) {
+
+    fun calculateFee(): Double {
+        return ratePolicy.calculateFee(this)
+    }
+
+    companion object {
+        const val MINIMUM_USAGE = 1
+        const val LOW_USAGE = 200
+        const val HIGH_USAGE = 400
+    }
+
+}

--- a/ElectricityChargePolicy.kt
+++ b/ElectricityChargePolicy.kt
@@ -1,6 +1,6 @@
-class ElectricityChargePolicy: BasicRatePolicy() {
+class ElectricityChargePolicy: RatePolicy {
 
-    override fun calculateElectricityChargePolicy(electricity: Electricity): Double {
+    override fun calculateFee(electricity: Electricity): Double {
         val result = if(electricity.usage < Electricity.MINIMUM_USAGE) {
             0.0
         } else if(electricity.usage in (Electricity.MINIMUM_USAGE + 1)..<Electricity.LOW_USAGE) {

--- a/ElectricityChargePolicy.kt
+++ b/ElectricityChargePolicy.kt
@@ -1,0 +1,22 @@
+class ElectricityChargePolicy: BasicRatePolicy() {
+
+    override fun calculateElectricityChargePolicy(electricity: Electricity): Double {
+        val result = if(electricity.usage < Electricity.MINIMUM_USAGE) {
+            0.0
+        } else if(electricity.usage in (Electricity.MINIMUM_USAGE + 1)..<Electricity.LOW_USAGE) {
+            electricity.usage * MINIMUM_RATE_FEE
+        } else if(electricity.usage in (Electricity.LOW_USAGE + 1)..<Electricity.HIGH_USAGE) {
+            (Electricity.LOW_USAGE * MINIMUM_RATE_FEE) + ((electricity.usage - Electricity.MINIMUM_USAGE) * LOW_RATE_FEE)
+        } else {
+            (Electricity.LOW_USAGE * MINIMUM_RATE_FEE) + (Electricity.LOW_USAGE * LOW_RATE_FEE) + ((electricity.usage - Electricity.HIGH_USAGE) * HIGH_RATE_FEE)
+        }
+        return result
+    }
+
+    companion object {
+        private const val MINIMUM_RATE_FEE = 115.0
+        private const val LOW_RATE_FEE = 206.6
+        private const val HIGH_RATE_FEE = 307.3
+    }
+
+}

--- a/PowerIndustryRatePolicy.kt
+++ b/PowerIndustryRatePolicy.kt
@@ -1,0 +1,9 @@
+class PowerIndustryRatePolicy(private val ratePolicies: List<RatePolicy>) : AdditionalRatePolicy(ratePolicies) {
+    override fun afterCalculated(fee: Double): Double {
+        return fee * VALUE_ADDED_TAX_RATE
+    }
+
+    companion object {
+        const val VALUE_ADDED_TAX_RATE = 0.37
+    }
+}

--- a/PowerIndustryRatePolicy.kt
+++ b/PowerIndustryRatePolicy.kt
@@ -4,6 +4,6 @@ class PowerIndustryRatePolicy(private val ratePolicies: List<RatePolicy>) : Addi
     }
 
     companion object {
-        const val VALUE_ADDED_TAX_RATE = 0.37
+        const val VALUE_ADDED_TAX_RATE = 0.037
     }
 }

--- a/RatePolicy.kt
+++ b/RatePolicy.kt
@@ -1,0 +1,3 @@
+interface RatePolicy {
+    fun calculateFee(electricity: Electricity): Double
+}

--- a/ValueAddedTaxPolicy.kt
+++ b/ValueAddedTaxPolicy.kt
@@ -1,0 +1,9 @@
+class ValueAddedTaxPolicy(private val ratePolicies: List<RatePolicy>) : AdditionalRatePolicy(ratePolicies) {
+    override fun afterCalculated(fee: Double): Double {
+        return fee * VALUE_ADDED_TAX_RATE
+    }
+
+    companion object {
+        const val VALUE_ADDED_TAX_RATE = 0.1
+    }
+}


### PR DESCRIPTION
# 주요 변경 내용
## 전기세 계산
![제목 없는 다이어그램 drawio](https://github.com/user-attachments/assets/8477f208-6c7c-4bc7-a9b8-7421a6db7318)


전기세 계산은 기본 요금 + 전력량 요금 + 부가세 + 전력 산업 기반 기금 + 기후 환경 요금 으로 계산하였습니다  
다음과 같이 요금 계산 로직 클래스를 생성하였습니다

- BasicRatePolicy : 기본 요금
- ElectricityChargePolicy : 전력량 요금
- ValueAddedTaxPolicy : 부가세
- PowerIndustryRatePolicy :  전력 산업 기반 기금
- ClimateEnvironmentRatePolicy : 기후 환경 요금

![제목 없는 다이어그램 drawio (1)](https://github.com/user-attachments/assets/73201d5d-1d2b-4125-b454-24d01796e6e5)


기본 요금과 전력량 요금 그리고 기후 환경 요금은 기본 정책으로 분류하였습니다  
기본 정책으로 분류된 요금들은 Electricity 타입의 멤버 변수를 사용해서 요금을 계산합니다  
기본 요금과 전력량 요금 사이에 중복되는 코드가 없어서 따로 또 abstract 클래스를 만들지는 않았습니다  
기후 환경 요금은 전력량에 기후 환경 단가(9.0원 / 변동 가능성 있음) 곱한 값입니다
  
부가세, 전력 산업 기반 기금, 기후 환경 요금은 모두 부가 정책으로 분류하였습니다
해당 요금들은 모두 다음과 같이 계산됩니다

- 전력 산업 기반 기금 : 전력량 요금 * 3.7%
- 부가세 : (기본 요금 + 전력량 요금 + 기후 환경 요금) * 10%

부가 정책으로 분류된 요금들은 모두 AdditionalRatePolicy 를 상속받습니다  
이 부가 정책 요금들은 이전에 전력량 요금, 기본 요금과 같은 기본 정책 요금들 계산이 되어야 하므로,  
AdditionalRatePolicy 에서 RatePolicy 를 리스트로 갖고 있게 하여 각 RatePolicy 에서 계산된 요금을 더한 값을 상속받은 자식 클래스에서 활용하도록 하였습니다  
